### PR TITLE
Review and fix the old code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Now `RawIOChunk` instances can be used as a context manager.
 - Implement `truncate` for `RawIOChunk`.
 - Add tests to ensure that `RawIOChunk` behaves consistently with all the other
-  `RawIOBase` implementations.
+  Now `RawIOChunk` implements `IO` interface.
+- Implement `IO` interface for `RawIOChunk`.
 ### Removed
 - Remove Python 2 support.
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Add isort, black, pre-commit.
+- Add typing, mypy.
+### Removed
+- Remove Python 2 support.
+### Changed
 - Change `README.rst` to `README.md`.
 - Replace `setup.py` with `pyproject.toml`.
-- Add isort, black, pre-commit.
-- Remove Python 2 support.
-- Add typing, mypy.
+### Fixed
+- Now returns an empty bytes instead of raising `EOFError` when the underlying
+  stream is empty.
 
 ## [1.0.2] - 2017-07-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Add isort, black, pre-commit.
 - Add typing, mypy.
+- Now `RawIOChunk` instances can be closed.
 ### Removed
 - Remove Python 2 support.
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add isort, black, pre-commit.
 - Add typing, mypy.
 - Now `RawIOChunk` instances can be closed.
+- Add `ClosedStreamError` exception, which inherits from `ValueError`.
 ### Removed
 - Remove Python 2 support.
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 - Now returns an empty bytes instead of raising `EOFError` when the underlying
   stream is empty.
+- Raise `ValueError` when trying to seek at a negative position.
 
 ## [1.0.2] - 2017-07-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add typing, mypy.
 - Now `RawIOChunk` instances can be closed.
 - Add `ClosedStreamError` exception, which inherits from `ValueError`.
+- Now `RawIOChunk` instances can be used as a context manager.
 ### Removed
 - Remove Python 2 support.
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Now returns an empty bytes instead of raising `EOFError` when the underlying
   stream is empty.
 - Raise `ValueError` when trying to seek at a negative position.
+- Prevent to reach negative seek positions.
 
 ## [1.0.2] - 2017-07-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Add `ClosedStreamError` exception, which inherits from `ValueError`.
 - Now `RawIOChunk` instances can be used as a context manager.
 - Implement `truncate` for `RawIOChunk`.
+- Add tests to ensure that `RawIOChunk` behaves consistently with all the other
+  `RawIOBase` implementations.
 ### Removed
 - Remove Python 2 support.
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Now `RawIOChunk` instances can be closed.
 - Add `ClosedStreamError` exception, which inherits from `ValueError`.
 - Now `RawIOChunk` instances can be used as a context manager.
+- Implement `truncate` for `RawIOChunk`.
 ### Removed
 - Remove Python 2 support.
 ### Changed

--- a/io_chunks/chunks.py
+++ b/io_chunks/chunks.py
@@ -140,6 +140,8 @@ class RawIOChunk(RawIOBase):
         if not isinstance(whence, int):
             raise TypeError(f"whence: expected int, got {type(whence)}")
         if whence == SEEK_SET:
+            if pos < 0:
+                raise ValueError("negative seek value -10")
             self._cursor = pos
         elif whence == SEEK_CUR:
             self._cursor += pos

--- a/io_chunks/chunks.py
+++ b/io_chunks/chunks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from io import (
     SEEK_CUR,
     SEEK_END,
@@ -6,7 +8,8 @@ from io import (
     RawIOBase,
     UnsupportedOperation,
 )
-from typing import Optional, Union
+from types import TracebackType
+from typing import Optional, Type, Union
 
 
 class ClosedStreamError(ValueError):
@@ -77,6 +80,19 @@ class RawIOChunk(RawIOBase):
     def end(self) -> int:
         """End position of the chunk"""
         return self._start + self._size
+
+    def __enter__(self) -> RawIOChunk:
+        if self.closed:
+            raise ClosedStreamError()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        self.close()
 
     # The type definition of `array` in `RawIOBase` of Python 3.7 is as
     # follows:

--- a/io_chunks/chunks.py
+++ b/io_chunks/chunks.py
@@ -170,8 +170,6 @@ class RawIOChunk(RawIOBase):
 
         Does NOT close the underlying stream.
         """
-        if self.closed:
-            return
         self._closed = True
 
     @property

--- a/io_chunks/chunks.py
+++ b/io_chunks/chunks.py
@@ -149,6 +149,8 @@ class RawIOChunk(RawIOBase):
             self._cursor = self._size + pos
         else:
             raise ValueError(f"whence: invalid value: {whence}")
+        if self._cursor < 0:
+            self._cursor = 0
         return self._cursor
 
     def tell(self) -> int:

--- a/io_chunks/chunks.py
+++ b/io_chunks/chunks.py
@@ -153,6 +153,19 @@ class RawIOChunk(RawIOBase):
             self._cursor = 0
         return self._cursor
 
+    def truncate(self, size: Optional[int] = None) -> int:
+        """
+        Resize the chunk to the given size, or to the current position if size is
+        `None`.
+        The current position isn't changed.
+        """
+        if size is None:
+            size = self._cursor
+        elif size < 0:
+            raise ValueError("negative size value -1")
+        self._size = size
+        return self._size
+
     def tell(self) -> int:
         if self.closed:
             raise ClosedStreamError()

--- a/io_chunks/chunks.py
+++ b/io_chunks/chunks.py
@@ -9,6 +9,11 @@ from io import (
 from typing import Optional, Union
 
 
+class ClosedStreamError(ValueError):
+    def __init__(self):
+        super().__init__("I/O operation on closed chunk")
+
+
 class RawIOChunk(RawIOBase):
     """
     An IO read-only object with access to a portion of another IO object.
@@ -90,7 +95,7 @@ class RawIOChunk(RawIOBase):
         return 0, even if there was remaining bytes in the chunk.
         """
         if self.closed:
-            raise ValueError("I/O operation on closed stream")
+            raise ClosedStreamError()
         if len(array) == 0:
             return 0
         remaining = self._size - self._cursor
@@ -113,7 +118,7 @@ class RawIOChunk(RawIOBase):
 
     def seek(self, pos: int, whence: int = 0) -> int:
         if self.closed:
-            raise ValueError("I/O operation on closed stream")
+            raise ClosedStreamError()
         if not isinstance(pos, int):
             raise TypeError(f"pos: expected int, got {type(pos)}")
         if not isinstance(whence, int):
@@ -130,17 +135,17 @@ class RawIOChunk(RawIOBase):
 
     def tell(self) -> int:
         if self.closed:
-            raise ValueError("I/O operation on closed stream")
+            raise ClosedStreamError()
         return self._cursor
 
     def seekable(self) -> bool:
         if self.closed:
-            raise ValueError("I/O operation on closed stream")
+            raise ClosedStreamError()
         return True
 
     def readable(self) -> bool:
         if self.closed:
-            raise ValueError("I/O operation on closed stream")
+            raise ClosedStreamError()
         return True
 
     def close(self) -> None:

--- a/io_chunks/chunks.py
+++ b/io_chunks/chunks.py
@@ -9,7 +9,7 @@ from io import (
     UnsupportedOperation,
 )
 from types import TracebackType
-from typing import Optional, Type, Union
+from typing import IO, Optional, Type, Union
 
 
 class ClosedStreamError(ValueError):
@@ -17,7 +17,7 @@ class ClosedStreamError(ValueError):
         super().__init__("I/O operation on closed chunk")
 
 
-class RawIOChunk(RawIOBase):
+class RawIOChunk(RawIOBase, IO):
     """
     An IO read-only object with access to a portion of another IO object.
     In other terms, a sub-stream of a stream.
@@ -196,7 +196,7 @@ class RawIOChunk(RawIOBase):
         """
         return self._stream.closed or self._closed
 
-    def write(self, *args, **kwargs) -> None:
+    def write(self, bytes) -> int:
         """
         This streams doesn't support writing.
 

--- a/tests/test_chunks.py
+++ b/tests/test_chunks.py
@@ -2,7 +2,7 @@ from io import SEEK_CUR, SEEK_END, BytesIO
 
 import pytest
 
-from io_chunks import RawIOChunk
+from io_chunks.chunks import ClosedStreamError, RawIOChunk
 
 
 def test_file_begin():
@@ -49,7 +49,7 @@ def test_stream_closed():
         chunk = RawIOChunk(buffer, size=5)
         assert chunk.closed is False
     assert chunk.closed is True
-    with pytest.raises(ValueError):
+    with pytest.raises(ClosedStreamError):
         chunk.read()
 
 
@@ -80,7 +80,7 @@ def test_closed_read_error():
     with BytesIO(b"0123456789") as buffer:
         chunk = RawIOChunk(buffer, size=5)
         chunk.close()
-        with pytest.raises(ValueError):
+        with pytest.raises(ClosedStreamError):
             chunk.read()
 
 
@@ -88,7 +88,7 @@ def test_closed_seek_error():
     with BytesIO(b"0123456789") as buffer:
         chunk = RawIOChunk(buffer, size=5)
         chunk.close()
-        with pytest.raises(ValueError):
+        with pytest.raises(ClosedStreamError):
             chunk.seek(0)
 
 

--- a/tests/test_chunks.py
+++ b/tests/test_chunks.py
@@ -44,7 +44,7 @@ def test_eof():
         assert chunk.read() == b""
 
 
-def test_closed():
+def test_stream_closed():
     with BytesIO(b"01234") as buffer:
         chunk = RawIOChunk(buffer, size=5)
         assert chunk.closed is False
@@ -66,3 +66,35 @@ def test_seek():
         assert chunk.read() == b"789"
         assert chunk.seek(0) == 0
         assert chunk.read() == b"56789"
+
+
+def test_close():
+    with BytesIO(b"0123456789") as buffer:
+        chunk = RawIOChunk(buffer, size=5)
+        chunk.close()
+        assert chunk.closed is True
+        assert buffer.closed is False
+
+
+def test_closed_read_error():
+    with BytesIO(b"0123456789") as buffer:
+        chunk = RawIOChunk(buffer, size=5)
+        chunk.close()
+        with pytest.raises(ValueError):
+            chunk.read()
+
+
+def test_closed_seek_error():
+    with BytesIO(b"0123456789") as buffer:
+        chunk = RawIOChunk(buffer, size=5)
+        chunk.close()
+        with pytest.raises(ValueError):
+            chunk.seek(0)
+
+
+def test_closed_tell_error():
+    with BytesIO(b"0123456789") as buffer:
+        chunk = RawIOChunk(buffer, size=5)
+        chunk.close()
+        with pytest.raises(ValueError):
+            chunk.tell()

--- a/tests/test_chunks.py
+++ b/tests/test_chunks.py
@@ -66,6 +66,8 @@ def test_seek():
         assert chunk.read() == b"789"
         assert chunk.seek(0) == 0
         assert chunk.read() == b"56789"
+        assert chunk.seek(0) == 0
+        assert chunk.seek(-1, SEEK_CUR) == 0
 
 
 def test_close():

--- a/tests/test_chunks.py
+++ b/tests/test_chunks.py
@@ -96,5 +96,22 @@ def test_closed_tell_error():
     with BytesIO(b"0123456789") as buffer:
         chunk = RawIOChunk(buffer, size=5)
         chunk.close()
-        with pytest.raises(ValueError):
+        with pytest.raises(ClosedStreamError):
             chunk.tell()
+
+
+def test_context_manager():
+    with BytesIO(b"0123456789") as buffer:
+        with RawIOChunk(buffer, size=5) as chunk:
+            assert chunk.closed is False
+        assert chunk.closed is True
+
+
+def test_double_context_manager_fails():
+    with BytesIO(b"0123456789") as buffer:
+        chunk = RawIOChunk(buffer, size=5)
+        with chunk as _:
+            pass
+        with pytest.raises(ClosedStreamError):
+            with chunk as _:
+                pass

--- a/tests/test_chunks.py
+++ b/tests/test_chunks.py
@@ -76,28 +76,22 @@ def test_close():
         assert buffer.closed is False
 
 
-def test_closed_read_error():
+@pytest.mark.parametrize(
+    "action",
+    [
+        lambda buffer: buffer.read(),
+        lambda buffer: buffer.seek(0),
+        lambda buffer: buffer.tell(),
+        lambda buffer: buffer.seekable(),
+        lambda buffer: buffer.readable(),
+    ],
+)
+def test_closed_stream_error(action):
     with BytesIO(b"0123456789") as buffer:
         chunk = RawIOChunk(buffer, size=5)
         chunk.close()
         with pytest.raises(ClosedStreamError):
-            chunk.read()
-
-
-def test_closed_seek_error():
-    with BytesIO(b"0123456789") as buffer:
-        chunk = RawIOChunk(buffer, size=5)
-        chunk.close()
-        with pytest.raises(ClosedStreamError):
-            chunk.seek(0)
-
-
-def test_closed_tell_error():
-    with BytesIO(b"0123456789") as buffer:
-        chunk = RawIOChunk(buffer, size=5)
-        chunk.close()
-        with pytest.raises(ClosedStreamError):
-            chunk.tell()
+            action(chunk)
 
 
 def test_context_manager():

--- a/tests/test_chunks.py
+++ b/tests/test_chunks.py
@@ -111,3 +111,30 @@ def test_double_context_manager_fails():
         with pytest.raises(ClosedStreamError):
             with chunk as _:
                 pass
+
+
+def test_flush():
+    with BytesIO(b"01234") as buffer:
+        chunk = RawIOChunk(buffer, size=2)
+        assert chunk.closed is False
+        chunk.flush()
+        assert chunk.closed is False
+
+
+def test_isatty():
+    with BytesIO(b"01234") as buffer:
+        chunk = RawIOChunk(buffer, size=2)
+        assert chunk.isatty() is False
+
+
+def test_readline():
+    with BytesIO(b"01234\n56789") as buffer:
+        chunk = RawIOChunk(buffer, size=5, start=2)
+        assert chunk.readline() == b"234\n"
+        assert chunk.readline() == b"5"
+
+
+def test_readlines():
+    with BytesIO(b"01234\n56789") as buffer:
+        chunk = RawIOChunk(buffer, size=5, start=2)
+        assert chunk.readlines() == [b"234\n", b"5"]

--- a/tests/test_io_compat.py
+++ b/tests/test_io_compat.py
@@ -1,0 +1,85 @@
+"""
+These tests are aimed to ensure that the `RawIOChunk` instances behave consistently with
+the other `IOBase` implementations.
+"""
+
+from io import BytesIO, IOBase, StringIO
+from itertools import product
+from tempfile import TemporaryFile
+from typing import IO, Callable, Union
+
+import pytest
+
+from io_chunks.chunks import RawIOChunk
+
+IOFactory = Callable[[], Union[IO, IOBase]]
+
+
+def temp_file_factory(contents: bytes, buffering=-1) -> IO:
+    temp_file = TemporaryFile("w+b", buffering=buffering)
+    temp_file.write(contents)
+    temp_file.seek(0)
+    return temp_file
+
+
+@pytest.mark.parametrize(
+    ["factory", "readed", "empty"],
+    [
+        (lambda: BytesIO(b"01234"), b"01234", b""),
+        (lambda: StringIO("01234"), "01234", ""),
+        (lambda: RawIOChunk(BytesIO(b"01234"), size=4), b"0123", b""),
+        (lambda: RawIOChunk(BytesIO(b"01234"), size=5), b"01234", b""),
+        (lambda: RawIOChunk(BytesIO(b"01234"), size=6), b"01234", b""),
+        (lambda: temp_file_factory(b"01234"), b"01234", b""),
+        (lambda: temp_file_factory(b"01234", buffering=0), b"01234", b""),
+    ],
+)
+def test_read(factory: IOFactory, readed: Union[bytes, str], empty: Union[bytes, str]):
+    with factory() as instance:
+        result = instance.read()
+        assert result == readed
+        assert instance.read() == empty
+        assert instance.read(1) == empty
+
+
+@pytest.mark.parametrize(
+    ["factory", "action"],
+    product(
+        [
+            lambda: BytesIO(b"000"),
+            lambda: StringIO("000"),
+            lambda: RawIOChunk(BytesIO(b"000"), size=1),
+            lambda: temp_file_factory(b"000"),
+            lambda: temp_file_factory(b"000", buffering=0),
+        ],
+        [
+            lambda buffer: buffer.read(),
+            lambda buffer: buffer.seek(0),
+            lambda buffer: buffer.tell(),
+            lambda buffer: buffer.seekable(),
+            lambda buffer: buffer.readable(),
+        ],
+    ),
+)
+def test_closed_raise_value_error(factory: IOFactory, action: Callable[[IO], None]):
+    with factory() as instance:
+        assert instance.closed is False
+        instance.close()
+        assert instance.closed is True
+
+
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda: BytesIO(b"000"),
+        lambda: StringIO("000"),
+        lambda: RawIOChunk(BytesIO(b"000"), size=1),
+        lambda: temp_file_factory(b"000"),
+        lambda: temp_file_factory(b"000", buffering=0),
+    ],
+)
+def test_closed_values(factory: IOFactory):
+    with factory() as instance:
+        assert instance.tell() == 0
+        assert instance.readable() is True
+        assert instance.seekable() is True

--- a/tests/test_io_compat.py
+++ b/tests/test_io_compat.py
@@ -4,17 +4,18 @@ the other `RawIOBase` implementations.
 """
 
 import os
-import re
-from io import SEEK_CUR, SEEK_END, BytesIO, RawIOBase
+from contextlib import nullcontext as does_not_raise
+from dataclasses import dataclass
+from io import SEEK_CUR, SEEK_END, BufferedIOBase, BytesIO, RawIOBase
 from itertools import product
 from tempfile import TemporaryFile
-from typing import IO, Callable, Type
+from typing import IO, Any, Callable, ContextManager
 
 import pytest
 
 from io_chunks.chunks import RawIOChunk
 
-RawIOFactory = Callable[[], RawIOBase]
+IOFactory = Callable[[], IO]
 
 
 def temp_file_factory(contents: bytes, buffering=-1) -> IO:
@@ -24,229 +25,252 @@ def temp_file_factory(contents: bytes, buffering=-1) -> IO:
     return temp_file
 
 
-@pytest.mark.parametrize(
-    ["factory", "readed"],
-    [
-        (lambda: BytesIO(b"01234"), b"01234"),
-        (lambda: RawIOChunk(BytesIO(b"01234"), size=4), b"0123"),
-        (lambda: RawIOChunk(BytesIO(b"01234"), size=5), b"01234"),
-        (lambda: RawIOChunk(BytesIO(b"01234"), size=6), b"01234"),
-        (lambda: temp_file_factory(b"01234"), b"01234"),
-        (lambda: temp_file_factory(b"01234", buffering=0), b"01234"),
-    ],
+@dataclass(frozen=True)
+class UseCase:
+    """
+    Represent a supported use case to check compatibility with the `RawIOBase` or to
+    verify it.
+    Contains all the results and expectations of all the tests.
+
+    This allows to have all the use case definitions in a single place.
+    """
+
+    factory: IOFactory
+    name: str
+    size: int
+    full_read_result: bytes
+    negative_seek_expect: ContextManager[Any]
+    before_start_seek_expect: ContextManager[Any]
+    seek_hole_expect: ContextManager[Any]
+    seek_data_expect: ContextManager[Any]
+    truncate_negative_expect: ContextManager[Any]
+
+
+@dataclass(frozen=True)
+class ClosedAction:
+    """
+    The secondary part of the use cases for the `test_closed_raises_value_error`
+    """
+
+    action: Callable[[IO], Any]
+    name: str
+
+
+USE_CASES = [
+    UseCase(
+        factory=lambda: BytesIO(b"01234"),
+        name="BytesIO",
+        size=5,
+        full_read_result=b"01234",
+        negative_seek_expect=pytest.raises(ValueError),
+        before_start_seek_expect=does_not_raise(),
+        seek_hole_expect=pytest.raises(ValueError),
+        seek_data_expect=pytest.raises(ValueError),
+        truncate_negative_expect=pytest.raises(ValueError),
+    ),
+    UseCase(
+        factory=lambda: RawIOChunk(BytesIO(b"01234"), size=4),
+        name="RawIOChunk (size 4)",
+        size=4,
+        full_read_result=b"0123",
+        negative_seek_expect=pytest.raises(ValueError),
+        before_start_seek_expect=does_not_raise(),
+        seek_hole_expect=pytest.raises(ValueError),
+        seek_data_expect=pytest.raises(ValueError),
+        truncate_negative_expect=pytest.raises(ValueError),
+    ),
+    UseCase(
+        factory=lambda: RawIOChunk(BytesIO(b"01234"), size=5),
+        name="RawIOChunk (size 5)",
+        size=5,
+        full_read_result=b"01234",
+        negative_seek_expect=pytest.raises(ValueError),
+        before_start_seek_expect=does_not_raise(),
+        seek_hole_expect=pytest.raises(ValueError),
+        seek_data_expect=pytest.raises(ValueError),
+        truncate_negative_expect=pytest.raises(ValueError),
+    ),
+    UseCase(
+        factory=lambda: RawIOChunk(BytesIO(b"01234"), size=6),
+        name="RawIOChunk (size 6)",
+        size=6,
+        full_read_result=b"01234",
+        negative_seek_expect=pytest.raises(ValueError),
+        before_start_seek_expect=does_not_raise(),
+        seek_hole_expect=pytest.raises(ValueError),
+        seek_data_expect=pytest.raises(ValueError),
+        truncate_negative_expect=pytest.raises(ValueError),
+    ),
+    UseCase(
+        factory=lambda: temp_file_factory(b"01234"),
+        name="TempFile",
+        size=5,
+        full_read_result=b"01234",
+        negative_seek_expect=pytest.raises(OSError),
+        before_start_seek_expect=pytest.raises(OSError),
+        seek_hole_expect=does_not_raise(),
+        seek_data_expect=does_not_raise(),
+        truncate_negative_expect=pytest.raises(OSError),
+    ),
+    UseCase(
+        factory=lambda: temp_file_factory(b"01234", buffering=0),
+        name="TempFile (unbuffered)",
+        size=5,
+        full_read_result=b"01234",
+        negative_seek_expect=pytest.raises(OSError),
+        before_start_seek_expect=pytest.raises(OSError),
+        seek_hole_expect=does_not_raise(),
+        seek_data_expect=does_not_raise(),
+        truncate_negative_expect=pytest.raises(OSError),
+    ),
+]
+
+CLOSED_ACTIONS = [
+    ClosedAction(lambda buffer: buffer.read(), name="read"),
+    ClosedAction(lambda buffer: buffer.seek(0), name="seek"),
+    ClosedAction(lambda buffer: buffer.tell(), name="tell"),
+    ClosedAction(lambda buffer: buffer.seekable(), name="seekable"),
+    ClosedAction(lambda buffer: buffer.readable(), name="readable"),
+]
+
+use_cases_param = pytest.mark.parametrize(
+    "use_case", USE_CASES, ids=lambda param: param.name
 )
-def test_read(factory: RawIOFactory, readed: bytes):
-    with factory() as instance:
+
+
+@use_cases_param
+def test_full_read(use_case: UseCase):
+    with use_case.factory() as instance:
         result = instance.read()
-        assert result == readed
+        assert result == use_case.full_read_result
         assert instance.read() == b""
         assert instance.read(1) == b""
 
 
 @pytest.mark.parametrize(
-    ["factory", "action"],
-    product(
-        [
-            lambda: BytesIO(b"000"),
-            lambda: RawIOChunk(BytesIO(b"000"), size=1),
-            lambda: temp_file_factory(b"000"),
-            lambda: temp_file_factory(b"000", buffering=0),
-        ],
-        [
-            lambda buffer: buffer.read(),
-            lambda buffer: buffer.seek(0),
-            lambda buffer: buffer.tell(),
-            lambda buffer: buffer.seekable(),
-            lambda buffer: buffer.readable(),
-        ],
-    ),
+    ["use_case", "action"],
+    product(USE_CASES, CLOSED_ACTIONS),
+    ids=lambda param: param.name,
 )
-def test_closed_raise_value_error(
-    factory: RawIOFactory, action: Callable[[RawIOBase], None]
-):
-    with factory() as instance:
+def test_closed_raises_value_error(use_case: UseCase, action: ClosedAction):
+    with use_case.factory() as instance:
         assert instance.closed is False
+        action.action(instance)
         instance.close()
         assert instance.closed is True
+        with pytest.raises(ValueError):
+            action.action(instance)
 
 
-@pytest.mark.parametrize(
-    "factory",
-    [
-        lambda: BytesIO(b"000"),
-        lambda: RawIOChunk(BytesIO(b"000"), size=1),
-        lambda: temp_file_factory(b"000"),
-        lambda: temp_file_factory(b"000", buffering=0),
-    ],
-)
-def test_closed_values(factory: RawIOFactory):
-    with factory() as instance:
+@use_cases_param
+def test_closed_values(use_case: UseCase):
+    with use_case.factory() as instance:
         assert instance.tell() == 0
         assert instance.seek(0) == 0
         assert instance.readable() is True
         assert instance.seekable() is True
 
 
-@pytest.mark.parametrize(
-    "factory",
-    [
-        lambda: BytesIO(b"000"),
-        lambda: RawIOChunk(BytesIO(b"000"), size=1),
-        lambda: temp_file_factory(b"000"),
-        lambda: temp_file_factory(b"000", buffering=0),
-    ],
-    ids=["BytesIO", "RawIOChunk", "TempFile", "TempFile (unbuffered)"],
-)
-def test_extra_seek(factory: RawIOFactory):
-    with factory() as instance:
+@use_cases_param
+def test_extra_seek(use_case: UseCase):
+    with use_case.factory() as instance:
         assert instance.seek(100) == 100
         assert instance.tell() == 100
 
 
-@pytest.mark.parametrize(
-    ["factory", "exception"],
-    [
-        (lambda: BytesIO(b"000"), ValueError),
-        (lambda: RawIOChunk(BytesIO(b"000"), size=1), ValueError),
-        (lambda: temp_file_factory(b"000"), OSError),
-        (lambda: temp_file_factory(b"000", buffering=0), OSError),
-    ],
-    ids=["BytesIO", "RawIOChunk", "TempFile", "TempFile (unbuffered)"],
-)
-def test_negative_seek(factory: RawIOFactory, exception: Type[Exception]):
-    with factory() as instance:
-        with pytest.raises(exception):
-            assert instance.seek(-10) == -10
+@use_cases_param
+def test_negative_seek(use_case: UseCase):
+    with use_case.factory() as instance:
+        with use_case.negative_seek_expect:
+            instance.seek(-1)
 
 
-@pytest.mark.parametrize(
-    "factory",
-    [
-        lambda: BytesIO(b"000"),
-        lambda: RawIOChunk(BytesIO(b"000"), size=3),
-    ],
-    ids=["BytesIO", "RawIOChunk"],
-)
-def test_relative_seek(factory: RawIOFactory):
-    with factory() as instance:
+@use_cases_param
+def test_seek_inside(use_case: UseCase):
+    with use_case.factory() as instance:
         assert instance.seek(0) == 0
-        assert instance.seek(-2, SEEK_END) == 1
+        assert instance.seek(1) == 1
+
+
+@use_cases_param
+def test_seek_outside(use_case: UseCase):
+    with use_case.factory() as instance:
+        assert instance.seek(10) == 10
+
+
+@use_cases_param
+def test_seek_end_inside(use_case: UseCase):
+    with use_case.factory() as instance:
+        assert instance.seek(-1, SEEK_END) == use_case.size - 1
+
+
+@use_cases_param
+def test_seek_end_outside(use_case: UseCase):
+    with use_case.factory() as instance:
+        with use_case.before_start_seek_expect:
+            assert instance.seek(-10, SEEK_END) == 0
+
+
+@use_cases_param
+def test_seek_cur_inside(use_case: UseCase):
+    with use_case.factory() as instance:
+        assert instance.seek(1) == 1
         assert instance.seek(1, SEEK_CUR) == 2
         assert instance.seek(-1, SEEK_CUR) == 1
         assert instance.seek(-1, SEEK_CUR) == 0
-        assert instance.seek(-1, SEEK_CUR) == 0
-        assert instance.seek(-4, SEEK_END) == 0
 
 
-@pytest.mark.parametrize(
-    "factory",
-    [
-        lambda: temp_file_factory(b"000"),
-        lambda: temp_file_factory(b"000", buffering=0),
-    ],
-    ids=["TempFile", "TempFile (unbuffered)"],
-)
-def test_relative_seek_oserror(factory: RawIOFactory):
-    with factory() as instance:
-        assert instance.seek(0) == 0
-        assert instance.seek(-2, SEEK_END) == 1
-        assert instance.seek(1, SEEK_CUR) == 2
-        assert instance.seek(-1, SEEK_CUR) == 1
-        assert instance.seek(-1, SEEK_CUR) == 0
-        with pytest.raises(OSError, match=re.escape(r"[Errno 22] Invalid argument")):
-            instance.seek(-1, SEEK_CUR)
-        with pytest.raises(OSError, match=re.escape(r"[Errno 22] Invalid argument")):
-            assert instance.seek(-4, SEEK_END) == 0
+@use_cases_param
+def test_seek_cur_ouside(use_case: UseCase):
+    with use_case.factory() as instance:
+        with use_case.before_start_seek_expect:
+            assert instance.seek(-1, SEEK_CUR) == 0
 
 
-@pytest.mark.parametrize(
-    "factory",
-    [
-        lambda: BytesIO(b"000"),
-        lambda: RawIOChunk(BytesIO(b"000"), size=1),
-    ],
-)
-def test_seek_hole_error(factory: RawIOFactory):
-    with factory() as instance:
-        with pytest.raises(ValueError):
-            instance.seek(0, os.SEEK_DATA)
-        with pytest.raises(ValueError):
-            instance.seek(0, os.SEEK_HOLE)
+@use_cases_param
+def test_seek_hole(use_case: UseCase):
+    with use_case.factory() as instance:
+        with use_case.seek_hole_expect:
+            instance.seek(0, os.SEEK_HOLE) == 0
 
 
-@pytest.mark.parametrize(
-    "factory",
-    [
-        lambda: temp_file_factory(b"000"),
-        lambda: temp_file_factory(b"000", buffering=0),
-    ],
-)
-def test_seek_hole_valid(factory: RawIOFactory):
-    with factory() as instance:
-        assert instance.seek(0, os.SEEK_DATA) == 0
-        assert instance.seek(0, os.SEEK_HOLE) == 3
+@use_cases_param
+def test_seek_data(use_case: UseCase):
+    with use_case.factory() as instance:
+        with use_case.seek_hole_expect:
+            instance.seek(0, os.SEEK_DATA) == 3
 
 
-@pytest.mark.parametrize(
-    "factory",
-    [
-        lambda: BytesIO(b"000"),
-        lambda: RawIOChunk(BytesIO(b"000"), size=1),
-        lambda: temp_file_factory(b"000"),
-        lambda: temp_file_factory(b"000", buffering=0),
-    ],
-)
-def test_pos_invalid_type(factory: RawIOFactory):
-    with factory() as instance:
+@use_cases_param
+def test_pos_invalid_type(use_case: UseCase):
+    with use_case.factory() as instance:
         with pytest.raises(TypeError):
             instance.seek("a")  # type: ignore[arg-type]
         with pytest.raises(TypeError):
             instance.seek(1, "a")  # type: ignore[arg-type]
 
 
-@pytest.mark.parametrize(
-    "factory",
-    [
-        lambda: BytesIO(b"000"),
-        lambda: RawIOChunk(BytesIO(b"000"), size=1),
-        lambda: temp_file_factory(b"000"),
-        lambda: temp_file_factory(b"000", buffering=0),
-    ],
-)
-def test_readinto_empty_array(factory: RawIOFactory):
-    with factory() as instance:
+@use_cases_param
+def test_readinto_empty_array(use_case: UseCase):
+    with use_case.factory() as instance:
+        # readinto is not in IO or IOBase but in RawIOBase and BufferedIOBase.
+        # While this test is not part of the IO contract, it *is* part of the RawIOBase
+        # contract, the class RawIOChunk inherits.
+        assert isinstance(instance, (RawIOBase, BufferedIOBase))
         buffer = bytearray(0)
         assert instance.readinto(buffer) == 0
         assert buffer == b""
 
 
-@pytest.mark.parametrize(
-    ["factory", "readed"],
-    [
-        (lambda: BytesIO(b"000"), b"00"),
-        (lambda: RawIOChunk(BytesIO(b"000"), size=3), b"00"),
-        (lambda: temp_file_factory(b"000"), b"00"),
-        (lambda: temp_file_factory(b"000", buffering=0), b"00"),
-    ],
-    ids=["BytesIO", "RawIOChunk", "TempFile", "TempFile (unbuffered)"],
-)
-def test_truncate(factory: RawIOFactory, readed: bytes):
-    with factory() as instance:
+@use_cases_param
+def test_truncate(use_case: UseCase):
+    with use_case.factory() as instance:
         assert instance.truncate(2) == 2
-        assert instance.read() == readed
+        assert instance.read() == b"01"
 
 
-@pytest.mark.parametrize(
-    ["factory", "exception"],
-    [
-        (lambda: BytesIO(b"000"), ValueError),
-        (lambda: RawIOChunk(BytesIO(b"000"), size=1), ValueError),
-        (lambda: temp_file_factory(b"000"), OSError),
-        (lambda: temp_file_factory(b"000", buffering=0), OSError),
-    ],
-    ids=["BytesIO", "RawIOChunk", "TempFile", "TempFile (unbuffered)"],
-)
-def test_truncate_negative(factory: RawIOFactory, exception: Type[Exception]):
-    with factory() as instance:
-        with pytest.raises(exception):
+@use_cases_param
+def test_truncate_negative(use_case: UseCase):
+    with use_case.factory() as instance:
+        with use_case.truncate_negative_expect:
             assert instance.truncate(-1) == 0


### PR DESCRIPTION
This includes lots of fixes to the old code, which didn't fulfilled the `io` library contracts correctly.

Also includes a new test suite to show how `RawIOChunk` fulfills its contracts and how it behaves compared to other binary `io` implementations.